### PR TITLE
Improved usage of .PHONY-target as per make manual

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ CFLAGS+=-g
 
 LDFLAGS+=-g
 
-.PHONY:
+.PHONY: testcontinue test libs install clean
 
 all: libs testcontinue
 
@@ -47,10 +47,10 @@ $(LIBNAME).so.$(LIBVER): $(OBJS)
 $(LIBNAME).a:	$(OBJS)
 	$(AR) rcs $@ $(OBJS)
 
-testcontinue: .PHONY
+testcontinue:
 	make -C tests $@
 
-test: .PHONY
+test:
 	make -C tests $@
 
 install:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -8,6 +8,8 @@ LDFLAGS += -lpthread -lrt -lz
 #CFLAGS += -O0 -pg
 #LDFLAGS += -pg
 
+.PHONY: all clean
+
 all:
 	@echo "# Examples are built individually"
 	@echo " make rdvarint"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,8 @@
 
 # Makefile wrapper for expanding 0*.c glob.
 
+.PHONY: all test clean testcontinue
+
 all test clean:
 	@echo "=================== SELFTESTS ======================="
 	@(export TEST_SRCS="`echo 0*.c`"; make -B -f Makefile.tests $@)


### PR DESCRIPTION
After reading http://www.gnu.org/software/make/manual/make.html#Phony-Targets I think the make files can be improved. I hope I did the pull request correctly, it's my first :)
