### PR TITLE
Move LIST_MOVE to new definition & ifdef guards

### DIFF
--- a/rdsysqueue.h
+++ b/rdsysqueue.h
@@ -175,12 +175,14 @@
  * Some extra functions for LIST manipulation
  */
 
-#define LIST_MOVE(newhead, oldhead, field) do {			        \
-        if((oldhead)->lh_first) {					\
-           (oldhead)->lh_first->field.le_prev = &(newhead)->lh_first;	\
-	}								\
-        (newhead)->lh_first = (oldhead)->lh_first;			\
-} while (0) 
+#ifndef LIST_MOVE
+#define LIST_MOVE(head1, head2) do {                                    \
+        LIST_INIT((head2));                                             \
+        if (!LIST_EMPTY((head1))) {                                     \
+                (head2)->lh_first = (head1)->lh_first;                  \
+                LIST_INIT((head1));                                     \
+        }                                                               \
+#endif
 
 #define LIST_INSERT_SORTED(head, elm, field, cmpfunc) do {	\
         if(LIST_EMPTY(head)) {					\


### PR DESCRIPTION
Some bsd-headers (the one in Alpine linux bsd-libs, for example) already
define it own LIST_MOVE macro, that collides with librd currently
defined one.

It can't be solved with ifdef macro, since alpine's one has different
macro arguments, so librd moves to alpine's definition. It will break
current librd LIST_MOVE users, but mantain compatibility with projects
that already uses alpine-like LIST_MOVE macros and want to integrate
librd.