### PR TITLE
Add variadic args to rd_calloc_struct

### DIFF
--- a/rdmem.c
+++ b/rdmem.c
@@ -207,12 +207,12 @@ size_t rd_memctx_freeall (rd_memctx_t *rmc) {
 
 
 
-void *rd_calloc_struct0 (rd_memctx_t *rmc, size_t base_size, ...) {
-	va_list ap;
+void *vrd_calloc_struct0 (rd_memctx_t *rmc, size_t base_size, va_list t_ap) {
 	size_t tot_size = base_size;
 	int pass;
 	char *tail = NULL;
 	void *ptr = NULL;
+	va_list ap;
 
 	/*
 	 * 1) Pass 1: calculate total memory size.
@@ -225,7 +225,7 @@ void *rd_calloc_struct0 (rd_memctx_t *rmc, size_t base_size, ...) {
 		int elem_size;
 		void *elem_src, **elem_dst;
 
-		va_start(ap, base_size);
+		va_copy(ap, t_ap);
 		while ((elem_size = va_arg(ap, int)) != RD_MEM_END_TOKEN) {
 			elem_src = va_arg(ap, void *);
 			elem_dst = va_arg(ap, void **);

--- a/rdmem.h
+++ b/rdmem.h
@@ -32,6 +32,8 @@
 #include "rdqueue.h"
 #include "rdthread.h"
 
+#include <stdarg.h>
+
 /**
  * Single allocation, when RD_MEMCTX_F_TRACK is used.
  */
@@ -194,7 +196,18 @@ size_t rd_memctx_freeall (rd_memctx_t *rmc);
 		*(pptr) = NULL;						\
 		*(pptr) = rd_calloc_struct0(rmc, base_size, ARGS);	\
 	} while (0)
-void *rd_calloc_struct0 (rd_memctx_t *rmc, size_t base_size, ...);
+void *vrd_calloc_struct0 (rd_memctx_t *rmc, size_t base_size, va_list ap);
+static void *rd_calloc_struct0(rd_memctx_t *rmc, size_t base_size, ...) RD_UNUSED;
+static void *rd_calloc_struct0(rd_memctx_t *rmc, size_t base_size, ...) {
+	void *ret = NULL;
+	va_list ap;
+
+	va_start(ap, base_size);
+	ret = vrd_calloc_struct0(rmc, base_size, ap);
+	va_end(ap);
+
+	return ret;
+}
 
 
 static inline char *rd_memctx_strdup(rd_memctx_t *memctx,const char *src) RD_UNUSED;


### PR DESCRIPTION
This way, rd_calloc_struct can be called with variadic arguments, so it
can be intercepted with tests tools.

This change is NOT ABI backwards compatible: apps using library needs to
be compiled again with new version to work properly.